### PR TITLE
Fix type in filter retrieval

### DIFF
--- a/ixusions.c
+++ b/ixusions.c
@@ -126,7 +126,7 @@ void ixusions_set_precedence(IxusionsContext context, IxusionsDevice device, Ixu
 IxusionsFilter ixusions_get_filter(IxusionsContext context, IxusionsDevice device)
 {
     IxusionsDeviceArray device_array = (IxusionsDeviceArray)context;
-    InterceptionFilter filter = 0;
+    IxusionsFilter filter = 0;
     DWORD bytes_returned;
 
     if(context && device_array[device - 1].handle)


### PR DESCRIPTION
## Summary
- correct variable type in `ixusions_get_filter`

## Testing
- `gcc -c ixusions.c -o ixusions.o` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68478f9e77248333b02f5254e73410a3